### PR TITLE
fix: use arel nodes in scopes

### DIFF
--- a/lib/temporalis/active_record.rb
+++ b/lib/temporalis/active_record.rb
@@ -9,7 +9,7 @@ module Temporalis
       def self.included(receiver)
         receiver.class_eval do
           scope :active_at, -> (timestamp) {
-            where("valid_since <= ? AND valid_until > ?", timestamp, timestamp)
+            where(arel_table[:valid_since].lteq(timestamp)).where(arel_table[:valid_until].gt(timestamp))
           }
 
           scope :descendants_of, -> (key) {


### PR DESCRIPTION
scopes are giving me issues when joining against multiple closure tables